### PR TITLE
converts the joiner to use traefik

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea
+.venv

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,22 +1,35 @@
-version: '2'
+version: '3.5'
 services:
   proxy:
-    image: jwilder/nginx-proxy:alpine
+    image: traefik
     container_name: proxy
+    networks:
+      - overlay
     ports:
       - "80:80"
       - "443:443"
     volumes:
-      - /var/run/docker.sock:/tmp/docker.sock:ro
-      - ./local-nginx-proxy.conf:/etc/nginx/conf.d/my_proxy.conf:ro
-      - ./vhost.d:/etc/nginx/vhost.d:ro
-      - ./certs/:/etc/nginx/certs:ro
+      - "./traefik.toml:/etc/traefik/traefik.toml"
+      - "./certs:/etc/ssl/certs/:ro"
+      - "/var/run/docker.sock:/var/run/docker.sock:ro"
+    labels:
+     - traefik.enable=true
+     - traefik.frontend.rule=Host:traefik.example.org
+     - traefik.backend=traefik
+     - traefik.port=8080
+    restart: on-failure
 
-  proxy-network-joiner:
+  joiner:
     build:
       context: ./network-joiner
-    container_name: proxy-network-joiner
+    networks:
+      - overlay
+    container_name: joiner
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - ./network-joiner/dpnj.py:/app/dpnj.py
-    command: python dpnj.py start
+    restart: on-failure
+
+networks:
+  overlay:
+    name: proxy_overlay

--- a/network-joiner/Dockerfile
+++ b/network-joiner/Dockerfile
@@ -1,7 +1,8 @@
-FROM python:3.6-alpine
+FROM python:3.7-alpine
 RUN mkdir -p /app
 WORKDIR /app
 COPY requirements.txt /app/
-RUN pip install -r requirements.txt
+RUN pip install --upgrade pip && pip install -r requirements.txt
 COPY . /app/
-CMD python lbreg.py
+ENTRYPOINT ["python", "dpnj.py"]
+CMD ["sync", "--watch", "--proxy-name", "proxy", "--proxy-network-name", "proxy_overlay"]

--- a/traefik.toml
+++ b/traefik.toml
@@ -1,0 +1,26 @@
+debug = true
+logLevel = "DEBUG"
+
+defaultEntryPoints = ["http", "https"]
+
+[docker]
+  endpoint = "unix:///var/run/docker.sock"
+  watch = true
+  domain = "example.org"
+  exposedbydefault = false
+
+[entryPoints]
+  [entryPoints.http]
+  address = ":80"
+    [entryPoints.http.redirect]
+    entryPoint = "https"
+  [entryPoints.https]
+  address = ":443"
+    [entryPoints.https.tls]
+      [[entryPoints.https.tls.certificates]]
+      certFile = "/etc/ssl/certs/example.org.crt"
+      keyFile = "/etc/ssl/certs/example.org.key"
+
+[api]
+  dashboard = true
+  entryPoint = "traefik"


### PR DESCRIPTION
This uses https://traefik.io/ instead of jwilder's nginx proxy as it's proven to be more stable *to me*. I also have a setup ready to use with the `sherpany.me` domain.

As this would completely replace the backend I'd also be open for it to be rejected, if so I'd just convert my fork to a `traefik-network-joiner` repo.